### PR TITLE
Функционал Clear Context

### DIFF
--- a/ai/templates/ai/chat.html
+++ b/ai/templates/ai/chat.html
@@ -127,7 +127,7 @@
             <textarea type="text" id="messageText" placeholder="Задайте вопрос (желательно на английском во избежание ошибок)" autocomplete="off"></textarea>
             <div>
             <button>Send</button>
-            <button>Clear Context</button>
+            <button type="button" onclick="clearContext()">Clear Context</button>
             <select id="selectLang">
                 <option language="Russian">Русский</option>
                 <option language="English">English</option>
@@ -181,7 +181,7 @@
         input.value = ''
         notEnter=false
     };
-    
+
     function sendMessage(event) {
     event.preventDefault();  // Эта строка вызывает ошибку, если event не передан
     if (ws.readyState === WebSocket.OPEN) {
@@ -194,6 +194,17 @@
         console.log("WebSocket is not open: " + ws.readyState);
     }
 }
+
+
+// Функция очистки контекста (истории переписки) ИИ
+    function clearContext() {
+        if (ws.readyState === WebSocket.OPEN) {
+            ws.send(JSON.stringify({action: 'clear_context'}));
+        } else {
+            console.log("WebSocket is not open: " + ws.readyState);
+        }
+}
+
 
 
     let isResizing = false;

--- a/ai/utils.py
+++ b/ai/utils.py
@@ -11,6 +11,7 @@ from requests.auth import HTTPBasicAuth
 from huggingface_hub import InferenceClient
 from dotenv import load_dotenv
 
+
 load_dotenv()
 CLIENT_ID = os.getenv("CLIENT_ID")
 SECRET = os.getenv("SBER_SECRET")
@@ -21,7 +22,6 @@ GROQ_TOKEN = os.getenv("GROQ_TOKEN")
 
 
 hist=dict([])
-
 
 async def ask_Meta_Llama_3_1_70B_Instruct_async(messages: str, user_id: int) -> str:
     if user_id not in hist:


### PR DESCRIPTION
Исправлена проблема с наличием словаря для хранения истории сообщений в двух файлах.

  Теперь словарь находится только в файле utils.py, из которого импортируется в consumers.py
- Добавлен функционал кнопке Clear Context, теперь она делает то, что и должна - очищает историю переписки с ИИ.